### PR TITLE
bypass yuchen's token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
         
       - name: Set up Java/Maven Environment #need a Maven environment to use "versions:set"
         uses: actions/setup-java@v4


### PR DESCRIPTION
I set a bypass for all roles with write access and used my personal token so the bot could use this bypass to update the version number in the pom.xml.