### PR TITLE
fix histogram and metrics

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,9 @@
 server.port=${PORT:8080}
-management.endpoints.web.exposure.include=prometheus
+
+# Actuator endpoints
+management.endpoints.web.exposure.include=health,prometheus,metrics
+management.endpoint.prometheus.enabled=true
+
+management.metrics.distribution.percentiles-histogram.app_sms_latency_seconds=true
+management.metrics.distribution.percentiles-histogram.app_sms_message_length=true
+


### PR DESCRIPTION
Might need to redeploy and helm upgrade to use the latest image.
Fixes A3 feedback on "There is no Histogram and the metrics are not broken down with labels"
- Enabled histogram buckets with publishPercentileHistogram(true)
- Added labels: result (spam/ham), cache_status (hit/miss/disabled)